### PR TITLE
Fix inverted logic in math parsing code.

### DIFF
--- a/src/sa1hybridizer/index.js
+++ b/src/sa1hybridizer/index.js
@@ -230,7 +230,11 @@ function process_word(word, index, splitted, comma_index, messages) {
 }
 
 function eval_stmt(string) {
-    return (new Function('return (' + string + ')')());
+    try {
+        return (new Function('return (' + string + ')')());
+    } catch (err) {
+        return NaN;
+    }
 }
 
 function convert(input) {
@@ -299,7 +303,7 @@ function convert(input) {
                 for (let [i, word] of splitted.entries()) {
                     if (word.startsWith('$')) {
                         let proc_word = parseInt(eval_stmt(word.replace('$', '0x')));
-                        if (Number.isNaN(proc_word)) {
+                        if (!Number.isNaN(proc_word)) {
                             let expr = word.replace('$', '').split(/[+\\\-^*~<>|]/);
                             word = `$${proc_word.toString(16).toUpperCase().padStart(Math.max(...expr.map((e) => e.length)), "0")}`;
                             word_tuples.push(new WordTuple(WordType.ADDR, word, i));


### PR DESCRIPTION
This commit fixes a logic problem in the math parsing code and catches any exceptions thrown by the new Function call in case the statement isn't valid js.
Returning NaN is sensible and the tool would do the correct thing in most cases.
A simple case to trigger the bug is `LDA $0123+($0122)` which now correctly translates to `LDA $0123|!addr+($0122|!addr)`